### PR TITLE
Fix api

### DIFF
--- a/lib/backend/repositories/nestingboxes_repository.dart
+++ b/lib/backend/repositories/nestingboxes_repository.dart
@@ -34,4 +34,30 @@ class NestingBoxesRepository {
       return null;
     }
   }
+
+  Future<List<NestingBox>> getAllNestingBoxPreviews() async {
+    final response = await nestingBoxesApi.getAllNestingBoxPreviews();
+    if (response.statusCode == 200) {
+      print(response.body);
+      final List results = json.decode(response.body);
+      return results
+          .map((nestingBox) => NestingBox.previewFromJson(nestingBox))
+          .toList();
+    } else {
+      print('Request failed');
+      return null;
+    }
+  }
+
+  Future<NestingBox> getNestingBoxPreviewById(String id) async {
+    final response = await nestingBoxesApi.getNestingBoxPreviewById(id);
+    if (response.statusCode == 200) {
+      print(response.body);
+      final Map result = json.decode(response.body);
+      return NestingBox.previewFromJson(result);
+    } else {
+      print('Request failed');
+      return null;
+    }
+  }
 }

--- a/lib/backend/services/auth/auth_api_service.dart
+++ b/lib/backend/services/auth/auth_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'auth_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/auth')
 abstract class AuthApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/backend/services/inspections/inspections_api_service.dart
+++ b/lib/backend/services/inspections/inspections_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'inspections_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/inspections')
 abstract class InspectionsApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/backend/services/nestingboxes/nestingboxes_api_service.chopper.dart
+++ b/lib/backend/services/nestingboxes/nestingboxes_api_service.chopper.dart
@@ -27,4 +27,18 @@ class _$NestingBoxesApiService extends NestingBoxesApiService {
     final $request = Request('GET', $url, client.baseUrl, headers: $headers);
     return client.send<dynamic, dynamic>($request);
   }
+
+  Future<Response> getAllNestingBoxPreviews() {
+    final $url = '/nesting-boxes/previews';
+    final $headers = {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='};
+    final $request = Request('GET', $url, client.baseUrl, headers: $headers);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  Future<Response> getNestingBoxPreviewById(String id) {
+    final $url = '/nesting-boxes/previews/${id}';
+    final $headers = {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='};
+    final $request = Request('GET', $url, client.baseUrl, headers: $headers);
+    return client.send<dynamic, dynamic>($request);
+  }
 }

--- a/lib/backend/services/nestingboxes/nestingboxes_api_service.dart
+++ b/lib/backend/services/nestingboxes/nestingboxes_api_service.dart
@@ -3,13 +3,32 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'nestingboxes_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/nesting-boxes')
 abstract class NestingBoxesApiService extends ChopperService {
-  @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})
+  @Get(
+    headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='},
+  )
   Future<Response> getAllNestingBoxes();
 
-  @Get(path: '/{id}', headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})
+  @Get(
+    path: '/{id}',
+    headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='},
+  )
   Future<Response> getNestingBoxById(@Path('id') String id);
+
+  @Get(
+    path: '/previews',
+    headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='},
+  )
+  Future<Response> getAllNestingBoxPreviews();
+
+  @Get(
+    path: '/previews/{id}',
+    headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='},
+  )
+  Future<Response> getNestingBoxPreviewById(@Path('id') String id);
 
   static NestingBoxesApiService create() {
     final client = ChopperClient(

--- a/lib/backend/services/owners/owners_api_service.dart
+++ b/lib/backend/services/owners/owners_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'owners_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/owners')
 abstract class OwnersApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/backend/services/regions/regions_api_service.dart
+++ b/lib/backend/services/regions/regions_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'regions_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/regions')
 abstract class RegionsApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/backend/services/species/species_api_service.dart
+++ b/lib/backend/services/species/species_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'species_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/species')
 abstract class SpeciesApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/backend/services/users/users_api_service.dart
+++ b/lib/backend/services/users/users_api_service.dart
@@ -3,6 +3,8 @@ import 'package:nesteo_app/development/dev.dart';
 
 part 'users_api_service.chopper.dart';
 
+// IMPORTANT: The API-Services should never be used directly, only through one of the repositories
+
 @ChopperApi(baseUrl: '/users')
 abstract class UsersApiService extends ChopperService {
   @Get(headers: {'Authorization': 'Basic QWRtaW46QWRtaW4xMjM='})

--- a/lib/model/nestingbox.dart
+++ b/lib/model/nestingbox.dart
@@ -18,6 +18,9 @@ class NestingBox extends Equatable {
   final String imageFileName;
   final String comment;
   final String lastUpdated;
+  final String inspectionsCount;
+  final String lastInspected;
+  final bool isPreview;
 
   NestingBox({
     this.id,
@@ -34,6 +37,9 @@ class NestingBox extends Equatable {
     this.imageFileName,
     this.comment,
     this.lastUpdated,
+    this.inspectionsCount,
+    this.lastInspected,
+    this.isPreview,
   });
 
   @override
@@ -52,6 +58,9 @@ class NestingBox extends Equatable {
         imageFileName,
         comment,
         lastUpdated,
+        inspectionsCount,
+        lastInspected,
+        isPreview,
       ];
 
   @override
@@ -77,6 +86,23 @@ class NestingBox extends Equatable {
       imageFileName: json['imageFileName'],
       comment: json['comment'],
       lastUpdated: json['lastUpdated'],
+      inspectionsCount: json['inspectionsCount'],
+      lastInspected: json['lastInspected'],
+      isPreview: false,
+    );
+  }
+
+  factory NestingBox.previewFromJson(Map<String, dynamic> json) {
+    return new NestingBox(
+      id: json['id'],
+      region: Region.fromJson(json['region']),
+      oldId: json['oldId'],
+      foreignId: json['foreignId'],
+      coordinateLongitude: json['coordinateLongitude'],
+      coordinateLatitude: json['coordinateLatitude'],
+      inspectionsCount: json['inspectionsCount'],
+      lastInspected: json['lastInspected'],
+      isPreview: true,
     );
   }
 }

--- a/lib/model/nestingbox.dart
+++ b/lib/model/nestingbox.dart
@@ -18,7 +18,7 @@ class NestingBox extends Equatable {
   final String imageFileName;
   final String comment;
   final String lastUpdated;
-  final String inspectionsCount;
+  final int inspectionsCount;
   final String lastInspected;
   final bool isPreview;
 

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -17,6 +17,7 @@ void main() {
   group('API tests', () {
     group('Owners API tests', () {
       OwnersRepository ownersRepo;
+      int ownerId;
 
       setUp(() {
         ownersRepo = OwnersRepository();
@@ -25,11 +26,12 @@ void main() {
       test('Test /owners', () async {
         List<Owner> owners = await ownersRepo.getAllOwners();
         print(owners.toString());
+        ownerId = owners[0].id;
         expect(owners.length > 0, true);
       });
 
       test('Test /owners/{id}', () async {
-        Owner owner = await ownersRepo.getOwnerById(0);
+        Owner owner = await ownersRepo.getOwnerById(ownerId);
         if (owner != null) {
           print(owner.toString());
         }
@@ -37,6 +39,7 @@ void main() {
     });
     group('Users API tests', () {
       UsersRepository usersRepo;
+      String userId;
 
       setUp(() {
         usersRepo = UsersRepository();
@@ -45,12 +48,12 @@ void main() {
       test('Test /users', () async {
         List<User> users = await usersRepo.getAllUsers();
         print(users.toString());
+        userId = users[0].id;
         expect(users.length > 0, true);
       });
 
       test('Test /users/{id}', () async {
-        User user =
-            await usersRepo.getUserById("f80d95df-9e94-4646-9cbb-b4c7be679ce1");
+        User user = await usersRepo.getUserById(userId);
         if (user != null) {
           print(user.toString());
         }
@@ -70,6 +73,7 @@ void main() {
     });
     group('Region API tests', () {
       RegionsRepository regionsRepo;
+      int regionId;
 
       setUp(() {
         regionsRepo = RegionsRepository();
@@ -78,11 +82,12 @@ void main() {
       test('Test /regions', () async {
         List<Region> regions = await regionsRepo.getAllRegions();
         print(regions.toString());
+        regionId = regions[0].id;
         expect(regions.length > 0, true);
       });
 
       test('Test /regions/{id}', () async {
-        Region region = await regionsRepo.getRegionById(0);
+        Region region = await regionsRepo.getRegionById(regionId);
         if (region != null) {
           print(region.toString());
         }
@@ -110,6 +115,7 @@ void main() {
     });
     group('NestingBox API tests', () {
       NestingBoxesRepository nestingBoxRepo;
+      String nestingBoxId;
 
       setUp(() {
         nestingBoxRepo = NestingBoxesRepository();
@@ -119,14 +125,42 @@ void main() {
         List<NestingBox> nestingBoxes =
             await nestingBoxRepo.getAllNestingBoxes();
         print(nestingBoxes.toString());
+        if (nestingBoxes[0] != null) {
+          nestingBoxId = nestingBoxes[0].id;
+        }
         expect(nestingBoxes.length > 0, true);
+        expect(nestingBoxes[0].isPreview, false);
       });
 
       test('Test /nesting-boxes/{id}', () async {
-        NestingBox nestingBox =
-            await nestingBoxRepo.getNestingBoxById("F000001");
-        if (nestingBox != null) {
-          print(nestingBox.toString());
+        if (nestingBoxId != null) {
+          NestingBox nestingBox =
+              await nestingBoxRepo.getNestingBoxById(nestingBoxId);
+          if (nestingBox != null) {
+            print(nestingBox.toString());
+          }
+        }
+      });
+
+      test('Test /nesting-boxes/previews', () async {
+        List<NestingBox> nestingBoxes =
+            await nestingBoxRepo.getAllNestingBoxPreviews();
+        print(nestingBoxes.toString());
+        if (nestingBoxes[0] != null) {
+          nestingBoxId = nestingBoxes[0].id;
+          expect(nestingBoxes.length > 0, true);
+          expect(nestingBoxes[0].isPreview, true);
+        }
+      });
+
+      test('Test /nesting-boxes/previews/{id}', () async {
+        if (nestingBoxId != null) {
+          NestingBox nestingBox =
+              await nestingBoxRepo.getNestingBoxPreviewById(nestingBoxId);
+          if (nestingBox != null) {
+            print(nestingBox.toString());
+            expect(nestingBox.isPreview, true);
+          }
         }
       });
     });


### PR DESCRIPTION
* Added new fields to the NestingBox model (especially important for the  previews)
  * `lastInspected`, `inspectionCount`, `isPreview`
* Added new methods to the NestingBoxRepository that allows to retrieve preview-versions of NestingBoxes
  * NestingBoxes that are only previews could be used for the list or on the map
  * When `isPreview` is `true`, the NestingBox object only contains some of the usual data
    * `id`
    * `region`
    * `oldId`
    * `foreignId`
    * `coordinateLongitude`
    * `coordinateLatitude`
    * `inspectionsCount`
    * `lastInspected`
    * `isPreview`