### PR TITLE
Remove transition states

### DIFF
--- a/lib/blocs/pagecontrol_bloc/pagecontrol_bloc.dart
+++ b/lib/blocs/pagecontrol_bloc/pagecontrol_bloc.dart
@@ -11,70 +11,27 @@ class PageControlBloc extends Bloc<PageControlEvent, PageControlState> {
     PageControlEvent event,
   ) async* {
     if (event is GoToMapEvent) {
-      yield ToMapScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
-      yield MapScreenState();
-    }
-
-    if (event is MapEvent) {
       yield MapScreenState();
     }
 
     if (event is GoToBoxListEvent) {
-      yield ToBoxListScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
-      yield BoxListScreenState();
-    }
-
-    if (event is BoxListEvent) {
       yield BoxListScreenState();
     }
 
     if (event is GoToNewBoxEvent) {
-      yield ToNewBoxScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
-      yield NewBoxScreenState();
-    }
-
-    if (event is NewBoxEvent) {
       yield NewBoxScreenState();
     }
 
     if (event is GoToBoxInfoEvent) {
-      yield ToBoxInfoScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
-      yield BoxInfoScreenState();
-    }
-
-    if (event is BoxInfoEvent) {
       yield BoxInfoScreenState();
     }
 
     if (event is GoToInspectionEvent) {
-      yield ToInspectionScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
-      yield InspectionScreenState();
-    }
-
-    if (event is InspectionEvent) {
       yield InspectionScreenState();
     }
 
     if (event is GoToNewInspectionEvent) {
-      yield ToNewInspectionScreenState();
-
-      await Future.delayed(Duration(seconds: 1));
       yield NewInspectionScreenState();
     }
-
-    if (event is NewInspectionEvent) {
-      yield NewInspectionScreenState();
-    }
-    // TODO: Add the missing events / states here
   }
 }

--- a/lib/blocs/pagecontrol_bloc/pagecontrol_event.dart
+++ b/lib/blocs/pagecontrol_bloc/pagecontrol_event.dart
@@ -11,17 +11,7 @@ class GoToHomeEvent extends PageControlEvent {
   List<Object> get props => [];
 }
 
-class HomeEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
 class GoToMapEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
-class MapEvent extends PageControlEvent {
   @override
   List<Object> get props => [];
 }
@@ -31,17 +21,7 @@ class GoToBoxListEvent extends PageControlEvent {
   List<Object> get props => [];
 }
 
-class BoxListEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
 class GoToNewBoxEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
-class NewBoxEvent extends PageControlEvent {
   @override
   List<Object> get props => [];
 }
@@ -51,27 +31,12 @@ class GoToBoxInfoEvent extends PageControlEvent {
   List<Object> get props => [];
 }
 
-class BoxInfoEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
 class GoToInspectionEvent extends PageControlEvent {
   @override
   List<Object> get props => [];
 }
 
-class InspectionEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
 class GoToNewInspectionEvent extends PageControlEvent {
-  @override
-  List<Object> get props => [];
-}
-
-class NewInspectionEvent extends PageControlEvent {
   @override
   List<Object> get props => [];
 }

--- a/lib/blocs/pagecontrol_bloc/pagecontrol_state.dart
+++ b/lib/blocs/pagecontrol_bloc/pagecontrol_state.dart
@@ -11,27 +11,7 @@ class LoginScreenState extends PageControlState {
   List<Object> get props => [];
 }
 
-class ToHomeScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
-class HomeScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
-class ToMapScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
 class MapScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
-class ToBoxListScreenState extends PageControlState {
   @override
   List<Object> get props => [];
 }
@@ -41,17 +21,7 @@ class BoxListScreenState extends PageControlState {
   List<Object> get props => [];
 }
 
-class ToNewBoxScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
 class NewBoxScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
-class ToBoxInfoScreenState extends PageControlState {
   @override
   List<Object> get props => [];
 }
@@ -61,17 +31,7 @@ class BoxInfoScreenState extends PageControlState {
   List<Object> get props => [];
 }
 
-class ToInspectionScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
 class InspectionScreenState extends PageControlState {
-  @override
-  List<Object> get props => [];
-}
-
-class ToNewInspectionScreenState extends PageControlState {
   @override
   List<Object> get props => [];
 }

--- a/lib/frames.dart
+++ b/lib/frames.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:nesteo_app/blocs/onlinemode_bloc/onlinemode.dart';
 import 'package:nesteo_app/blocs/pagecontrol_bloc/pagecontrol.dart';
 import 'package:nesteo_app/blocs/snackbar_bloc/snackbar.dart';
@@ -101,10 +100,7 @@ class FramedScreen extends StatelessWidget {
             ),
             floatingActionButton: screen.floatingActionButton,
             bottomNavigationBar: BottomNavigationBar(
-              currentIndex:
-                  (state is MapScreenState || state is ToMapScreenState)
-                      ? 0
-                      : 1,
+              currentIndex: (state is MapScreenState) ? 0 : 1,
               selectedIconTheme: IconThemeData(size: 22),
               unselectedIconTheme: IconThemeData(size: 20),
               type: BottomNavigationBarType.fixed,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: nesteo_app
 description: Nesting box management app for ringing associations.
 
-version: 0.3.1+7
+version: 0.3.2+8
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/test/pagecontrol_test.dart
+++ b/test/pagecontrol_test.dart
@@ -16,15 +16,10 @@ void main() {
     test('Login to Transition to Map States working', () {
       final List<PageControlState> expected = [
         LoginScreenState(),
-        ToMapScreenState(),
         MapScreenState(),
-        ToBoxListScreenState(),
         BoxListScreenState(),
-        ToNewBoxScreenState(),
         NewBoxScreenState(),
-        ToBoxInfoScreenState(),
         BoxInfoScreenState(),
-        ToInspectionScreenState(),
         InspectionScreenState(),
       ];
 


### PR DESCRIPTION
I removed transitioning states and events as part of the pagecontrol cleanup.

The rest of the changes will be done at once, but the changes in this PR improve the app without changing functionality, so they can be merged to master.